### PR TITLE
thinking that the font-size is causing blanks, changed from 1.35rem t…

### DIFF
--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -52,7 +52,7 @@ li {
 #memo {
   font-family: 'Sen', sans-serif;
   border-radius: .25rem;
-  font-size: 1.35rem;
+  font-size: 1.5rem;
   padding: .25em;
   width: 95%;
 }


### PR DESCRIPTION
…o 1.5 rem, because when you enlarge the screen for even a moment you are then able to see the text on each chore card.